### PR TITLE
Fix MapMarker duplication

### DIFF
--- a/frontend-app/src/components/marker/MapMarker.jsx
+++ b/frontend-app/src/components/marker/MapMarker.jsx
@@ -1,15 +1,11 @@
-import React, {useContext} from 'react'
+import React from 'react'
 import { Marker } from 'react-map-gl'
 import LocationOnIcon from '@mui/icons-material/LocationOn'
-import { LocationContext } from '../../context/LocationContext'
-import { AuthContext } from '../../context/AuthContext'
 
-const MapMarker = () => {
-    const { currentUser } = useContext(AuthContext)
-    const { SetCurrentPlaceId , pins} = useContext(LocationContext)
+const MapMarker = ({ pins, currentUser, setCurrentPlaceId }) => {
 
     const handleMarkerClick = (id) => {
-        SetCurrentPlaceId(id)
+        setCurrentPlaceId(id)
         console.log(`${id}`)
     }
 

--- a/frontend-app/src/pages/MapPage.jsx
+++ b/frontend-app/src/pages/MapPage.jsx
@@ -18,7 +18,7 @@ const UserAuthentication = lazy(() => import('../components/authentication/UserA
 
 const MapPage = () => {
   const { currentUser } = useContext(AuthContext)
-  const { pins, SetPins, SetNewPlace } = useContext(LocationContext)
+  const { pins, SetPins, SetNewPlace, SetCurrentPlaceId } = useContext(LocationContext)
   const [viewport, setViewport] = useState({
     latitude: 6.927079,
     longitude: 79.861244,
@@ -139,16 +139,16 @@ const MapPage = () => {
         )}
 
 
+        <MapMarker
+          pins={pins}
+          currentUser={currentUser}
+          setCurrentPlaceId={SetCurrentPlaceId}
+        />
+
         {pins.map((p) => (
-          <React.Fragment key={p._id}>
-            {/* Retrieve all markers on Map */}
-            <MapMarker />
-            {/* Popup on Marker */}
-            <Suspense fallback={<Loader />}>
-              <MarkerPopup
-                p={p} />
-            </Suspense>
-          </React.Fragment>
+          <Suspense fallback={<Loader />} key={p._id}>
+            <MarkerPopup p={p} />
+          </Suspense>
         ))}
 
         {/* User popup creation */}


### PR DESCRIPTION
## Summary
- avoid nested loops when rendering map markers
- accept `pins`, `currentUser` and `setCurrentPlaceId` as props in `MapMarker`

## Testing
- `CI=true npm --workspace=frontend-app test --silent`

------
https://chatgpt.com/codex/tasks/task_e_685968b119dc83258bb1de06c340bcaf