### PR TITLE
Improve forms with shadcn components

### DIFF
--- a/frontend-app/src/App.css
+++ b/frontend-app/src/App.css
@@ -138,3 +138,24 @@
   100% { transform: rotate(360deg) }
 }
  
+/* shadcn components */
+.shadcn-card {
+  background-color: var(--white-color);
+  padding: 1rem;
+  border-radius: 0.5rem;
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+}
+
+.shadcn-input {
+  width: 100%;
+  padding: 0.5rem 0.75rem;
+  border-radius: 0.375rem;
+  border: 1px solid var(--gray-color);
+}
+
+.shadcn-alert {
+  padding: 0.75rem 1rem;
+  border-radius: 0.375rem;
+  background-color: rgb(224, 231, 255);
+  color: rgb(55, 65, 81);
+}

--- a/frontend-app/src/components/forms/login/Login.jsx
+++ b/frontend-app/src/components/forms/login/Login.jsx
@@ -3,6 +3,10 @@ import CancelIcon from '@mui/icons-material/Cancel'
 import { useRef, useState , useContext } from "react"
 import apiRequest from '../../../lib/ApiReqest'
 
+import Card from '../../ui/Card'
+import Input from '../../ui/Input'
+import Alert from '../../ui/Alert'
+
 import { AuthContext } from '../../../context/AuthContext'
 import "./login.css"
 import Swal from 'sweetalert2' //Sweet alert
@@ -43,24 +47,29 @@ const Login = ({ setShowLogin }) =>{
 
   return (
     <div className="loginContainer">
-      <div className="logo">
-        <LocationOnIcon className="logoIcon" />
-        <span>Map-Explore</span>
-      </div>
-      <form onSubmit={handleSubmit}>
-        <input autoFocus placeholder="username" ref={usernameRef} />
-        <input
-          type="password"
-          min="6"
-          placeholder="password"
-          ref={passwordRef}
+      <Card>
+        <div className="logo">
+          <LocationOnIcon className="logoIcon" />
+          <span>Map-Explore</span>
+        </div>
+        <form onSubmit={handleSubmit} className="loginForm">
+          <Input autoFocus placeholder="username" ref={usernameRef} />
+          <Input
+            type="password"
+            min="6"
+            placeholder="password"
+            ref={passwordRef}
+          />
+          <button className="loginBtn" type="submit">
+            Login
+          </button>
+          {error && <Alert>Something went wrong!</Alert>}
+        </form>
+        <CancelIcon
+          className="loginCancel"
+          onClick={() => setShowLogin(false)}
         />
-        <button className="loginBtn" type="submit">
-          Login
-        </button>
-        {error && <span className="failure">Something went wrong!</span>}
-      </form>
-      <CancelIcon className="loginCancel" onClick={() => setShowLogin(false)} />
+      </Card>
     </div>
   )
 }

--- a/frontend-app/src/components/forms/login/login.css
+++ b/frontend-app/src/components/forms/login/login.css
@@ -1,46 +1,37 @@
 .loginContainer {
-    width: 300px;
-    height: 200px;
-    padding: 20px;
-    border-radius: 10px;
-    background-color: var(--white-color);
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    margin: auto;
+    min-height: 100vh;
     display: flex;
-    flex-direction: column;
     align-items: center;
-    justify-content: space-between;
-  }
-  
-  .loginCancel {
+    justify-content: center;
+}
+
+.loginCancel {
     position: absolute;
     top: 3px;
     right: 3px;
     cursor: pointer;
-  }
-  
-  .logo {
+}
+
+.logo {
     display: flex;
     align-items: center;
     justify-content: center;
     color: var(--grey-color);
     font-weight: 700;
-  }
-  
-  .loginBtn {
+    margin-bottom: 1rem;
+}
+
+.loginForm {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    width: 300px;
+}
+
+.loginBtn {
     border: none;
     padding: 5px;
     background-color: var(--gray-color);
     color: var(--white-color);
     cursor: pointer;
-  }
-  
-  .failure {
-    font-size: 12px;
-    color: var(--red-color);
-    text-align: center;
-  }
+}

--- a/frontend-app/src/components/forms/newPopup/NewPopupForm.jsx
+++ b/frontend-app/src/components/forms/newPopup/NewPopupForm.jsx
@@ -2,6 +2,9 @@ import React, { useState, useContext} from 'react'
 import './newpopupform.css'
 import apiRequest from '../../../lib/ApiReqest'
 
+import Card from '../../ui/Card'
+import Input from '../../ui/Input'
+
 import {LocationContext} from "../../../context/LocationContext"
 import { AuthContext } from "../../../context/AuthContext"
 
@@ -36,32 +39,34 @@ const NewPopupForm = () => {
 
     return (
         <div>
-            <form onSubmit={handleSubmit}>
-                <label>Title</label>
-                <input
-                    placeholder="Enter a title"
-                    autoFocus
-                    value={title}
-                    onChange={(e) => setTitle(e.target.value)}
-                />
-                <label>Description</label>
-                <textarea
-                    placeholder="Say us something about this place."
-                    value={desc}
-                    onChange={(e) => setDesc(e.target.value)}
-                />
-                <label>Rating</label>
-                <select value={star} onChange={(e) => setStar(e.target.value)}>
-                    <option value="1">1</option>
-                    <option value="2">2</option>
-                    <option value="3">3</option>
-                    <option value="4">4</option>
-                    <option value="5">5</option>
-                </select>
-                <button type="submit" className="submitButton">
-                    Add Pin
-                </button>
-            </form>
+            <Card>
+                <form onSubmit={handleSubmit} className="popupForm">
+                    <label>Title</label>
+                    <Input
+                        placeholder="Enter a title"
+                        autoFocus
+                        value={title}
+                        onChange={(e) => setTitle(e.target.value)}
+                    />
+                    <label>Description</label>
+                    <textarea
+                        placeholder="Say us something about this place."
+                        value={desc}
+                        onChange={(e) => setDesc(e.target.value)}
+                    />
+                    <label>Rating</label>
+                    <select value={star} onChange={(e) => setStar(e.target.value)}>
+                        <option value="1">1</option>
+                        <option value="2">2</option>
+                        <option value="3">3</option>
+                        <option value="4">4</option>
+                        <option value="5">5</option>
+                    </select>
+                    <button type="submit" className="submitButton">
+                        Add Pin
+                    </button>
+                </form>
+            </Card>
         </div>
     )
 }

--- a/frontend-app/src/components/forms/newPopup/newpopupform.css
+++ b/frontend-app/src/components/forms/newPopup/newpopupform.css
@@ -1,39 +1,30 @@
-form {
+.popupForm {
     width: 250px;
-    height: 250px;
     display: flex;
     flex-direction: column;
-    justify-content: space-between;
+    gap: 1rem;
     color: var(--form-color);
-  }
-  
-  input {
-    border: none;
-    border-bottom: 1px solid var(--gray-color);
-  }
-  
-  input::placeholder,
-  textarea::placeholder {
+}
+
+.popupForm input,
+.popupForm textarea,
+.popupForm select {
+    border: 1px solid var(--gray-color);
+    padding: 0.5rem;
+    border-radius: 4px;
+}
+
+.popupForm input::placeholder,
+.popupForm textarea::placeholder {
     font-size: 12px;
     color: var(--placeholder-color);
-  }
-  
-  input:focus,
-  textarea:focus,
-  select:focus {
-    outline: none;
-  }
-  
-  textarea {
-    border: none;
-    border-bottom: 1px solid var(--gray-color);
-  }
-  
-  .submitButton {
+}
+
+.popupForm .submitButton {
     border: none;
     padding: 5px;
     border-radius: 5px;
     color: var(--white-color);
     background-color: var(--red-color);
     cursor: pointer;
-  }
+}

--- a/frontend-app/src/components/forms/register/Register.jsx
+++ b/frontend-app/src/components/forms/register/Register.jsx
@@ -4,6 +4,10 @@ import { useRef, useState } from "react"
 import apiRequest from '../../../lib/ApiReqest'
 import "./register.css"
 
+import Card from '../../ui/Card'
+import Input from '../../ui/Input'
+import Alert from '../../ui/Alert'
+
 const Register = ({ setShowRegister })=> {
   const [success, setSuccess] = useState(false)
   const [error, setError] = useState(false)
@@ -30,31 +34,33 @@ const Register = ({ setShowRegister })=> {
   }
   return (
     <div className="registerContainer">
-      <div className="logo">
-        <LocationOnIcon className="logoIcon" />
-        <span>Map-Explore</span>
-      </div>
-      <form onSubmit={handleSubmit}>
-        <input autoFocus placeholder="username" ref={usernameRef} />
-        <input type="email" placeholder="email" ref={emailRef} />
-        <input
-          type="password"
-          min="6"
-          placeholder="password"
-          ref={passwordRef}
+      <Card>
+        <div className="logo">
+          <LocationOnIcon className="logoIcon" />
+          <span>Map-Explore</span>
+        </div>
+        <form onSubmit={handleSubmit} className="registerForm">
+          <Input autoFocus placeholder="username" ref={usernameRef} />
+          <Input type="email" placeholder="email" ref={emailRef} />
+          <Input
+            type="password"
+            min="6"
+            placeholder="password"
+            ref={passwordRef}
+          />
+          <button className="registerBtn" type="submit">
+            Register
+          </button>
+          {success && (
+            <Alert>Successfull. You can login now!</Alert>
+          )}
+          {error && <Alert>Something went wrong!</Alert>}
+        </form>
+        <CancelIcon
+          className="registerCancel"
+          onClick={() => setShowRegister(false)}
         />
-        <button className="registerBtn" type="submit">
-          Register
-        </button>
-        {success && (
-          <span className="success">Successfull. You can login now!</span>
-        )}
-        {error && <span className="failure">Something went wrong!</span>}
-      </form>
-      <CancelIcon
-        className="registerCancel"
-        onClick={() => setShowRegister(false)}
-      />
+      </Card>
     </div>
   )
 }

--- a/frontend-app/src/components/forms/register/register.css
+++ b/frontend-app/src/components/forms/register/register.css
@@ -1,53 +1,38 @@
 .registerContainer {
-    width: 300px;
-    height: 250px;
-    padding: 20px;
-    border-radius: 10px;
-    background-color: var(--white-color);
-    position: absolute;
-    top: 0;
-    bottom: 0;
-    left: 0;
-    right: 0;
-    margin: auto;
+    min-height: 100vh;
     display: flex;
-    flex-direction: column;
     align-items: center;
-    justify-content: space-between;
-  }
-  
-  .registerCancel {
+    justify-content: center;
+}
+
+.registerCancel {
     position: absolute;
     top: 3px;
     right: 3px;
     cursor: pointer;
-  }
-  
-  .logo {
+}
+
+.logo {
     display: flex;
     align-items: center;
     justify-content: center;
     color: var(--blue-color);
     font-weight: 700;
-  }
-  
-  .registerBtn {
+    margin-bottom: 1rem;
+}
+
+.registerForm {
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    width: 300px;
+}
+
+.registerBtn {
     border: none;
     padding: 5px;
     background-color: var(--blue-color);
     color: var(--white-color);
     cursor: pointer;
-  }
-  
-  .success {
-    font-size: 14px;
-    color: var(--green-color);
-    text-align: center;
-  }
-  
-  .failure {
-    font-size: 14px;
-    color: var(--red-color);
-    text-align: center;
-  }
-  
+}
+

--- a/frontend-app/src/components/ui/Alert.jsx
+++ b/frontend-app/src/components/ui/Alert.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const Alert = ({ children, className = '' }) => {
+  return <div className={`shadcn-alert ${className}`}>{children}</div>
+}
+
+export default Alert

--- a/frontend-app/src/components/ui/Card.jsx
+++ b/frontend-app/src/components/ui/Card.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const Card = ({ children, className = '' }) => {
+  return <div className={`shadcn-card ${className}`}>{children}</div>
+}
+
+export default Card

--- a/frontend-app/src/components/ui/Input.jsx
+++ b/frontend-app/src/components/ui/Input.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+const Input = React.forwardRef(({ className = '', ...props }, ref) => {
+  return <input ref={ref} className={`shadcn-input ${className}`} {...props} />
+})
+
+export default Input


### PR DESCRIPTION
## Summary
- create simple shadcn-style `Card`, `Input` and `Alert` components
- wrap login, register and popup forms in the new `Card`
- replace plain inputs with `Input`
- show validation errors through `Alert`
- center modals using flexbox and add spacing between fields

## Testing
- `CI=true npm test --silent`

------
