### PR TITLE
Implement dark mode toggle

### DIFF
--- a/frontend-app/postcss.config.js
+++ b/frontend-app/postcss.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {},
+  },
+};

--- a/frontend-app/public/index.html
+++ b/frontend-app/public/index.html
@@ -8,10 +8,13 @@
       name="description"
       content="Web site created using create-react-app"
     />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;700&display=swap" rel="stylesheet" />
     <style>
-      *{
+      * {
         margin: 0;
-      font-family: 'Poppins', sans-serif;
+        font-family: 'Inter', sans-serif;
       }
     </style>
     <link href='https://api.tiles.mapbox.com/mapbox-gl-js/v<YOUR_MAPBOX_VERSION>/mapbox-gl.css' rel='stylesheet' />

--- a/frontend-app/src/App.css
+++ b/frontend-app/src/App.css
@@ -12,6 +12,16 @@
   
 
 }
+.dark {
+  --form-color: rgb(229, 229, 229);
+  --placeholder-color: rgb(170, 170, 170);
+  --gray-color: rgb(70, 70, 70);
+  --white-color: rgb(48, 48, 48);
+  --loader-color: rgb(255, 255, 255);
+  background-color: #121212;
+  color: var(--form-color);
+}
+
 
 .card {
     width: 250px;

--- a/frontend-app/src/components/ui/ThemeToggle.jsx
+++ b/frontend-app/src/components/ui/ThemeToggle.jsx
@@ -1,0 +1,20 @@
+import React, { useState, useEffect } from 'react'
+import Switch from '@mui/material/Switch'
+
+const ThemeToggle = () => {
+  const [enabled, setEnabled] = useState(false)
+
+  useEffect(() => {
+    document.body.classList.toggle('dark', enabled)
+  }, [enabled])
+
+  return (
+    <Switch
+      checked={enabled}
+      onChange={() => setEnabled(!enabled)}
+      inputProps={{ 'aria-label': 'theme toggle' }}
+    />
+  )
+}
+
+export default ThemeToggle

--- a/frontend-app/src/index.css
+++ b/frontend-app/src/index.css
@@ -1,0 +1,3 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;

--- a/frontend-app/src/index.js
+++ b/frontend-app/src/index.js
@@ -1,6 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App'
+import './index.css'
 import { AuthContextProvider } from "./context/AuthContext.jsx"
 import { LocationContextProvider } from './context/LocationContext.jsx'
 

--- a/frontend-app/src/pages/MapPage.jsx
+++ b/frontend-app/src/pages/MapPage.jsx
@@ -4,6 +4,7 @@ import axios from 'axios'
 import 'mapbox-gl/dist/mapbox-gl.css'
 import './mappage.css'
 import Loader from '../components/ui/Loader' //Loader for suspense
+import ThemeToggle from '../components/ui/ThemeToggle'
 import MyLocationIcon from '@mui/icons-material/MyLocation'
 import MapMarker from '../components/marker/MapMarker'
 import debounce from 'lodash.debounce' // Import debounce from lodash
@@ -89,6 +90,7 @@ const MapPage = () => {
     <div style={{ height: '100vh', width: '100%' }}>
       {/* Header containing search bar and add review button */}
       <div className="header">
+        <ThemeToggle />
         <div className="search-box">
           <input
             type="text"

--- a/frontend-app/src/pages/mappage.css
+++ b/frontend-app/src/pages/mappage.css
@@ -40,7 +40,7 @@ form {
   }
   
   .search-box {
-    background: white;
+    background: var(--white-color);
     padding: 10px 70px;
     border-radius: 5px;
     box-shadow: 0 0 5px rgba(0, 0, 0, 0.3);
@@ -52,9 +52,9 @@ form {
     outline: none;
   }
   
-  .add-review-button {  
-    background: #007bff;
-    color: white;
+  .add-review-button {
+    background: var(--blue-color);
+    color: var(--white-color);
     border: none;
     padding: 10px 20px;
     border-radius: 5px;
@@ -78,8 +78,8 @@ form {
     list-style: none;
     padding: 0;
     margin: 0;
-    background: white;
-    border: 1px solid #ccc;
+    background: var(--white-color);
+    border: 1px solid var(--gray-color);
     max-height: 200px;
     overflow-y: auto;
     position: absolute;
@@ -94,6 +94,16 @@ form {
   }
   
   .suggestions-list li:hover {
-    background: #f0f0f0;
+    background: var(--gray-color);
+  }
+
+  .dark .mapboxgl-ctrl button {
+    background-color: var(--white-color);
+    color: var(--form-color);
+  }
+
+  .dark .search-box,
+  .dark .suggestions-list {
+    color: var(--form-color);
   }
   

--- a/frontend-app/tailwind.config.js
+++ b/frontend-app/tailwind.config.js
@@ -1,0 +1,9 @@
+/** @type {import('tailwindcss').Config} */
+module.exports = {
+  content: ["./src/**/*.{js,jsx,ts,tsx}", "./public/index.html"],
+  darkMode: 'class',
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- load Inter font in HTML
- enable class-based dark mode in Tailwind
- add a switch to toggle dark mode
- style pages and map controls for dark mode

## Testing
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_685968c312c88325bda882f01d5ac3c7